### PR TITLE
Fixed error in setup: unknown file type '.pyx'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 
 from setuptools import setup
-from Cython.Distutils.extension import Extension
+from distutils.core import setup
+from distutils.extension import Extension
+from Cython.Distutils import build_ext
 
 include_dirs = ['lib', 'lib/libgraphqlparser', 'lib/gen', 'lib/gen/cython']
 sources = [
@@ -27,6 +29,7 @@ setup(
                   language='c++',
                   extra_compile_args=['-std=c++11']),
     ],
+    cmdclass= {'build_ext': build_ext},
     install_requires=[
         'Cython < 1'
     ],


### PR DESCRIPTION
It kept saying "unknown file type '.pyx'" with cython 0.29, so I've changed the `setup.py` according to this post: https://stackoverflow.com/questions/33520619/extra-compile-args-in-cython#33521863